### PR TITLE
Make it work on medium screen and below

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ then go to http://localhost:8000.
 
 ```
 # if not yet installed, run this once
-npm instal -g http-server
+npm install -g http-server
 
 # run server
 http-server

--- a/css/style.css
+++ b/css/style.css
@@ -1,6 +1,9 @@
-body {
+@media (min-width: 992px) {
+  body {
     overflow: hidden;
+  }
 }
+
 @font-face {
     font-family: 'PantonLight';
     src: url('../font/panton-light.ttf');
@@ -15,6 +18,7 @@ body {
 }
 .menu li {
     padding: 25px 20px;
+    /* TODO: not working well for medium screen size */
     font-size: 20px;
     font-family: PantonLight;
     line-height: 20px;
@@ -364,8 +368,7 @@ h4 {
    
 }
 #app-list .app-icon img {
-    width: 65%;
-     cursor: pointer;
+    cursor: pointer;
 }
 #app-list .app-icon h6 {
     font-family: PantonLight;
@@ -430,6 +433,7 @@ h4 {
     width: 55%;
     border: 2px #bdc3c7 solid;
     border-radius: 100%;
+    max-width: 200px;
 }
 .member-block p {
     font-size: 13px;
@@ -540,11 +544,16 @@ a.expand {
 #gif-image{
     position: absolute;
     top: 70px;
-    left: 40px;
+    left: 20px;
+    right: 17px;
+}
+.iphone-wireframe {
+    width: 251px;
+    margin: 0 auto;
 }
 
 #gif-image img {
-    width: 68%;
+    max-width: 100%;
 }
 .hide-image {
     display: none;  

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
             <div class="navbar-header">
 
                 <a class="navbar-brand" href="#">
-                    <img class="logo" src="img/small_cropped_afb4l1.1.png" />
+                    <img class="logo full-logo hidden-sm" src="img/small_cropped_afb4l1.1.png" />
                 </a>
             </div>
             <div id="navbar" class="navbar-collapse collapse">

--- a/index.html
+++ b/index.html
@@ -63,12 +63,14 @@
 
 
             <div id="center-block" class="col-md-4 no-side-padding">
-                <div class="iphone-wireframe text-center animated zoomIn">
-                    <img src="img/wireframe.png" />
-                    <div id="gif-image">
-                        <img src="#"/>
-                    </div>
+              <div class="frame-container">
+                <div class="iphone-wireframe animated zoomIn">
+                  <img src="img/wireframe.png" />
+                  <div id="gif-image">
+                    <img src="#"/>
+                  </div>
                 </div>
+              </div>
             </div>
 
             <div id="right-block" class="col-md-4 no-side-padding">


### PR DESCRIPTION
couldn't stand it when the beautiful site doesn't work on medium screen sizes and below. just some quick fixes:
- show scrollbar on smaller screens
- fix positioning of iphone frame and its gif content. TODO: currently do we require all GIFs to be of the same size now? iphone 5s size? 
- make author thumbnail not full width on small screen
- hide logo on small screen so that navbar doesn't overflow (even better if we use a (C) only logo)

ideally, someone should improve it further by making navbar behave properly on small screens. maybe use navbar collapse properly.
